### PR TITLE
switch to buffered channels to prevent blocking on write

### DIFF
--- a/pkg/authorizers/aws/verifier.go
+++ b/pkg/authorizers/aws/verifier.go
@@ -35,8 +35,8 @@ func NewVerifier() (server.Verifier, error) {
 
 // Verify is responsible for build a identification document
 func (a *awsNodeVerifier) VerifyIdentity(ctx context.Context) ([]byte, error) {
-	errs := make(chan error)
-	doneCh := make(chan []byte)
+	errs := make(chan error, 1)
+	doneCh := make(chan []byte, 1)
 
 	go func() {
 		encoded, err := func() ([]byte, error) {

--- a/pkg/server/admission.go
+++ b/pkg/server/admission.go
@@ -35,7 +35,7 @@ var (
 
 // authorizeNodeRequest is responsible for handling the incoming authorization request
 func (n *NodeAuthorizer) authorizeNodeRequest(ctx context.Context, request *NodeRegistration) error {
-	doneCh := make(chan error)
+	doneCh := make(chan error, 1)
 
 	// @step: create a context to run under
 	ctx, cancel := context.WithTimeout(ctx, n.config.AuthorizationTimeout)


### PR DESCRIPTION
Using unbuffered channels here could be causing a goroutine leak.

If `ctx.Done()` arrives first in the select block nothing will read from the unbuffered channels and then the goroutines which write to those channels will be blocked on write and not terminate. 