### PR TITLE
Allow offline verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev
     tags:
       - v*
 

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:alpine as builder
+# Cannot upgrade to 1.16. AWS certs will not validate
+FROM --platform=$BUILDPLATFORM golang:1.15-alpine as builder
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
@@ -15,7 +16,7 @@ COPY . /go/src/k8s.io/kops/node-authorizer/
 RUN CGO_ENABLED=0 go build -o ./node-authorizer -a -installsuffix cgo ./cmd/node-authorizer
 
 
-FROM alpine:3.11
+FROM alpine:3.13
 RUN apk --no-cache add ca-certificates
 COPY --from=0 /go/src/k8s.io/kops/node-authorizer/node-authorizer /node-authorizer
 ENTRYPOINT ["/node-authorizer"]

--- a/cmd/node-authorizer/server.go
+++ b/cmd/node-authorizer/server.go
@@ -103,6 +103,12 @@ func addServerCommand() cli.Command {
 				EnvVar: "AUTHORIZATION_TIMEOUT",
 				Value:  15 * time.Second,
 			},
+			cli.StringFlag{
+				Name:   "aws-account-override",
+				Usage:  "The AWS account ID of child nodes",
+				EnvVar: "AWS_ACCOUNT_OVERRIDE",
+				Value:  "",
+			},
 		},
 
 		Action: func(ctx *cli.Context) error {
@@ -124,6 +130,7 @@ func actionServerCommand(ctx *cli.Context) error {
 		TLSClientCAPath:      ctx.String("tls-client-ca"),
 		TLSPrivateKeyPath:    ctx.String("tls-private-key"),
 		TokenDuration:        ctx.Duration("token-ttl"),
+		AWSAccountOverride:   ctx.String("aws-account-override"),
 	}
 
 	if ctx.String("authorizer") == "" {

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -82,6 +82,8 @@ type Config struct {
 	TLSClientCAPath string
 	// TLSPrivateKeyPath is the path to the private key
 	TLSPrivateKeyPath string
+	// AWSAccountOverride overrides the expected AWS account ID
+	AWSAccountOverride string
 }
 
 // UseFeature indicates a feature is in use


### PR DESCRIPTION
Add the option to only perform cryptographic AWS verification, without hitting the AWS API.